### PR TITLE
fix generate keys paths and run command

### DIFF
--- a/examples/gcp-cloudrun-postgres/generate_keys.sh
+++ b/examples/gcp-cloudrun-postgres/generate_keys.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd ../../opr-core
-npx run generatekeypair -- --publicfile opr-public-key.json --privatefile opr-private-key.json
+cd ../../components/core
+npm run generatekeypair -- --publicfile opr-public-key.json --privatefile opr-private-key.json
 gsutil cp opr-public-key.json gs://$1-config/publickeys/opr-public-key.json
 gsutil cp opr-private-key.json gs://$1-config/opr-private-key.json
 rm opr-public-key.json


### PR DESCRIPTION
Fixes an issue with the paths and run command in the generate_keys script.